### PR TITLE
Renamed NIOOpenSSL->NIOSSL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     targets: [
         .target(name: "CMD5", dependencies: []),
-        .target(name: "NIOPostgres", dependencies: ["CMD5", "NIO", "NIOOpenSSL"]),
+        .target(name: "NIOPostgres", dependencies: ["CMD5", "NIO", "NIOSSL"]),
         .target(name: "NIOPostgresBenchmark", dependencies: ["NIOPostgres"]),
         .testTarget(name: "NIOPostgresTests", dependencies: ["NIOPostgres"]),
     ]

--- a/Sources/NIOPostgres/Connection/PostgresConnection+RequestTLS.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnection+RequestTLS.swift
@@ -1,10 +1,12 @@
+import NIOSSL
+
 extension PostgresConnection {
     public func requestTLS(using tlsConfig: TLSConfiguration) -> EventLoopFuture<Bool> {
         let tls = RequestTLSQuery()
         return self.send(tls).flatMapThrowing { _ in
             if tls.isSupported {
-                let sslContext = try SSLContext(configuration: tlsConfig)
-                let handler = try OpenSSLClientHandler(context: sslContext)
+                let sslContext = try NIOSSLContext(configuration: tlsConfig)
+                let handler = try NIOSSLClientHandler(context: sslContext)
                 _ = self.channel.pipeline.addHandler(handler, position: .first)
             }
             return tls.isSupported

--- a/Sources/NIOPostgres/Utilities/Exports.swift
+++ b/Sources/NIOPostgres/Utilities/Exports.swift
@@ -1,2 +1,2 @@
 @_exported import NIO
-@_exported import NIOOpenSSL
+@_exported import NIOSSL


### PR DESCRIPTION
https://github.com/apple/swift-nio-ssl/pull/75 changed the name name of the NIOOpenSSL package to NIOSSL, as well as a changing the name of a bunch of classes and structs.

This PR updates NIOPostgres to it can build against the master branch of swift-nio-ssl.