### PR TITLE
Swift NIO updates

### DIFF
--- a/Sources/NIOPostgres/Connection/PostgresConnection+Connect.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnection+Connect.swift
@@ -8,7 +8,7 @@ extension PostgresConnection {
         return bootstrap.connect(to: socketAddress).flatMap { channel in
             return channel.pipeline.addHandlers([
                 ByteToMessageHandler(PostgresMessageDecoder()),
-                PostgresMessageEncoder(),
+                MessageToByteHandler(PostgresMessageEncoder()),
                 PostgresConnectionHandler(),
             ]).map {
                 return .init(channel: channel)

--- a/Sources/NIOPostgres/Message/PostgresMessageEncoder.swift
+++ b/Sources/NIOPostgres/Message/PostgresMessageEncoder.swift
@@ -5,7 +5,7 @@ public final class PostgresMessageEncoder: MessageToByteEncoder {
     public typealias OutboundIn = PostgresMessage
     
     /// See `MessageToByteEncoder`.
-    public func encode(context: ChannelHandlerContext, data message: PostgresMessage, out: inout ByteBuffer) throws {
+    public func encode(data message: PostgresMessage, out: inout ByteBuffer) throws {
         // print("PostgresMessage.ChannelEncoder.encode(\(data))")
         
         // serialize identifier


### PR DESCRIPTION
Two tweaks to allow nio-postgres to build against the latest version of Swift-NIO.
- The signature for `encode()` in `MessageToByteEncoder` changed.
- The encoder also needs to be wrapped into a `MessageToByteHandler`