### PR TITLE
Handle Authentication Errors

### DIFF
--- a/Sources/NIOPostgres/Connection/PostgresConnection+Authenticate.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnection+Authenticate.swift
@@ -24,7 +24,11 @@ private final class PostgresAuthenticationRequest: PostgresRequestHandler {
     let database: String?
     let password: String?
     var state: State
-    
+
+    var errorMessageIsFinal: Bool {
+        return true
+    }
+
     init(username: String, database: String?, password: String?) {
         self.state = .ready
         self.username = username

--- a/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
@@ -11,6 +11,15 @@ extension PostgresConnection {
 public protocol PostgresRequestHandler {
     func respond(to message: PostgresMessage) throws -> [PostgresMessage]?
     func start() throws -> [PostgresMessage]
+
+    var errorMessageIsFinal: Bool {get}
+}
+
+
+extension PostgresRequestHandler {
+    var errorMessageIsFinal: Bool {
+        return false
+    }
 }
 
 // MARK: Private
@@ -48,7 +57,12 @@ final class PostgresConnectionHandler: ChannelDuplexHandler {
         switch message.identifier {
         case .error:
             let error = try PostgresMessage.Error(message: message)
-            request.error = PostgresError.server(error)
+            let postgresError = PostgresError.server(error)
+            if request.delegate.errorMessageIsFinal {
+                request.promise.fail(postgresError)
+                self.queue.removeFirst()
+            }
+            request.error = postgresError
         case .notice:
             let notice = try PostgresMessage.Error(message: message)
             print("[NIOPostgres] [NOTICE] \(notice)")

--- a/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
@@ -12,6 +12,7 @@ public protocol PostgresRequestHandler {
     func respond(to message: PostgresMessage) throws -> [PostgresMessage]?
     func start() throws -> [PostgresMessage]
 
+    #warning("TODO: Workaround for Authentication see #14")
     var errorMessageIsFinal: Bool { get }
 }
 

--- a/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
+++ b/Sources/NIOPostgres/Connection/PostgresConnectionHandler.swift
@@ -12,7 +12,7 @@ public protocol PostgresRequestHandler {
     func respond(to message: PostgresMessage) throws -> [PostgresMessage]?
     func start() throws -> [PostgresMessage]
 
-    var errorMessageIsFinal: Bool {get}
+    var errorMessageIsFinal: Bool { get }
 }
 
 

--- a/Tests/NIOPostgresTests/NIOPostgresTests.swift
+++ b/Tests/NIOPostgresTests/NIOPostgresTests.swift
@@ -284,4 +284,16 @@ final class NIOPostgresTests: XCTestCase {
             }
         }
     }
+
+    func testInvalidPassword() throws {
+        let auth = PostgresConnection.testUnauthenticated(on: eventLoop).flatMap({ (connection) in
+            connection.authenticate(username: "invalid", database: "invalid", password: "bad").map { connection }
+        })
+        do {
+            let _ = try auth.wait()
+            XCTFail("The authentication should fail")
+        } catch let error as PostgresError {
+           XCTAssertEqual(error.code, .invalid_password)
+        }
+    }
 }

--- a/Tests/NIOPostgresTests/XCTestManifests.swift
+++ b/Tests/NIOPostgresTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ extension NIOPostgresTests {
         ("testSelectPerformance", testSelectPerformance),
         ("testRangeSelectPerformance", testRangeSelectPerformance),
         ("testRangeSelectDecodePerformance", testRangeSelectDecodePerformance),
+        ("testInvalidPassword", testInvalidPassword),
     ]
 }
 


### PR DESCRIPTION
This PR adds a new property `errorMessageIsFinal` to the `PostgresRequestHandler` protocol.

During the authentication, when an error occurs (e.g. invalid password), the promise for the authentication never gets filled, because the current implementation of `PostgresConnectionHandler` expects that there is another message (e.g. ready for query) after an error occurred.

The authentication case is a bit special because the error message can be the last message here.

The better way to fix this, probably to add a state machine to the protocol to keep track of what messages we can expect. However, that is a bigger fix. If you'd like a PR for that, I am happy to send one, but that is probably a more significant change.

For now, this adds the `errorMessageIsFinal` and the `PostgresConnectionHandler` fails the promise immediately if the handler expects that behaviour.